### PR TITLE
Enhance supported patterns to include ** matching multilevel of subdomains

### DIFF
--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -14,6 +14,8 @@ import (
 
 const allowedDNSCharsREGroup = "[-a-zA-Z0-9_]"
 
+const enhancedDNSCharsREGroup = "[-a-zA-Z0-9_.]"
+
 // MatchAllAnchoredPattern is the simplest pattern that match all inputs. This resulting
 // parsed regular expression is the same as an empty string regex (""), but this
 // value is easier to reason about when serializing to and from json.
@@ -100,8 +102,14 @@ func escapeRegexpCharacters(pattern string) string {
 	// base case. "." becomes a literal .
 	pattern = strings.Replace(pattern, ".", "[.]", -1)
 
+        // ** becomes [-a-zA-Z0-9_.]#, # to bypass the next line
+	pattern = strings.Replace(pattern, "**", enhancedDNSCharsREGroup+"#", -1)
+
 	// base case. * becomes .*, but only for DNS valid characters
 	// NOTE: this only works because the case above does not leave the *
 	pattern = strings.Replace(pattern, "*", allowedDNSCharsREGroup+"*", -1)
+
+        // # becomes *
+	pattern = strings.Replace(pattern, "#", "*", -1)
 	return pattern
 }


### PR DESCRIPTION
Adding ** to match substrings as a prefix including subdomains.


<!-- Description of change -->
```
So far subdomains required a definition of all subdomains by adding a chain of star and dot.

Example:
rules:
  dns:
    - matchPattern: '*.cluster.local'
    - matchPattern: '*.*.cluster.local'
    - matchPattern: '*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.internal'
    - matchPattern: '*.*.*.*.internal'
    - matchPattern: '*.*.*.*.*.internal'
    - matchPattern: '*.*.*.*.*.*.internal'
    - matchPattern: '*.*.*.*.*.*.*.internal'
    - matchPattern: '*.*.*.*.*.*.*.*.internal'
    - matchPattern: '*.*.*.*.*.*.*.*.*.internal'
    - matchPattern: '*.*.internal.cloudapp.net'
    - matchPattern: '*.*.*.internal.cloudapp.net'
    - matchPattern: '*.*.*.*.internal.cloudapp.net'
    - matchPattern: '*.*.*.*.*.internal.cloudapp.net'
    - matchPattern: '*.*.*.*.*.*.internal.cloudapp.net'
    - matchPattern: '*.*.*.*.*.*.*.internal.cloudapp.net'
    - matchPattern: '*.*.*.*.*.*.*.*.internal.cloudapp.net'

A feature enhancement introduces wildcards where ** would represent 1 or more DNS subdomains. That would allow them to compress the above policy to:

rules:
  dns:
    - matchPattern: '**.cluster.local'
    - matchPattern: '**.internal'
    - matchPattern: '**.internal.cloudapp.net'

Th code modification does not change the old behaviour if someone want to list subdomains explicitly.

For example the policy:
apiVersion: cilium.io/v2
kind: CiliumNetworkPolicy
metadata:
  name: fqdn-policy
spec:
  endpointSelector: {}
  egress:
    - toFQDNs:
      - matchPattern: "*pl"
      - matchPattern: "*.io"
      - matchPattern: "**com"
      - matchPattern: "**.amazonaws.com"
    - toPorts:
      - ports:
         - port: "53"
           protocol: UDP
        rules:
          dns:
            - matchPattern: "*"
         
produces the following result:
Forbids domain.pl as expected by the old behaviour.
Allows cilium.io as expected by the old behaviour.
Allows google.com as expected by a new behaviour.
Allows elasticbeanstalk-eu-west-1-123456789000.s3-eu-west-1.amazonaws.com as expected by a new behaviour.
```
Release note:
```release-note
Enhance supported patterns to include ** matching multilevel of subdomains.

Instead of the rules with listed subdomains:

rules:
  dns:
    - matchPattern: '*.cluster.local'
    - matchPattern: '*.*.cluster.local'
    - matchPattern: '*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.*.*.*.cluster.local'

the following policy can be used:

rules:
  dns:
    - matchPattern: '**.cluster.local'
 
```
Signed-off-by: Piotr Jablonski <piotr.jablonski@isovalent.com>